### PR TITLE
Suppressing warnings

### DIFF
--- a/src/Dps310.cpp
+++ b/src/Dps310.cpp
@@ -82,6 +82,7 @@ int16_t Dps310::readcoeffs(void) {
     uint8_t buffer[18];
     //read COEF registers to buffer
     int16_t ret = readBlock(coeffBlock, buffer);
+    (void)ret; // UNUSED
 
     //compose coefficients from buffer content
     m_c0Half = ((uint32_t)buffer[0] << 4) | (((uint32_t)buffer[1] >> 4) & 0x0F);

--- a/src/DpsClass.cpp
+++ b/src/DpsClass.cpp
@@ -160,7 +160,7 @@ int16_t DpsClass::getSingleResult(float& result) {
         case 1: //measurement ready, expected case
             Mode oldMode = m_opMode;
             m_opMode = IDLE; //opcode was automatically reseted by DPS310
-            int32_t raw_val;
+            int32_t raw_val = 0;
             switch (oldMode) {
                 case CMD_TEMP: //temperature
                     getRawResult(&raw_val, registerBlocks[TEMP]);


### PR DESCRIPTION
* Dps310.cpp:84:13: warning: unused variable 'ret' [-Wunused-variable]
* DpsClass.cpp:171:42: warning: 'raw_val' may be used uninitialized in this function [-Wmaybe-uninitialized]
* DpsClass.cpp:163:21: note: 'raw_val' was declared here

https://github.com/Seeed-Studio/Wio_Tracker_1110_Examples/issues/17